### PR TITLE
Added support for Merknad

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 version=0-SNAPSHOT
-apiVersion=3.3.0-alpha-17
+apiVersion=3.3.0-alpha-19

--- a/src/main/java/no/fint/p360/SupportedActions.java
+++ b/src/main/java/no/fint/p360/SupportedActions.java
@@ -26,6 +26,7 @@ public class SupportedActions extends AbstractSupportedActions {
         add(ArkivActions.GET_ALL_JOURNALSTATUS);
         add(ArkivActions.GET_ALL_JOURNALPOSTTYPE);
         add(ArkivActions.GET_ALL_PARTROLLE);
+        add(ArkivActions.GET_ALL_MERKNADSTYPE);
         add(ArkivActions.GET_SAK);
         add(ArkivActions.GET_KORRESPONDANSEPART);
         add(ArkivActions.UPDATE_KORRESPONDANSEPART);

--- a/src/main/java/no/fint/p360/data/KodeverkRepository.java
+++ b/src/main/java/no/fint/p360/data/KodeverkRepository.java
@@ -8,6 +8,7 @@ import no.fint.p360.data.noark.dokumenttype.DokumenttypeService;
 import no.fint.p360.data.noark.journalposttype.JournalpostTypeService;
 import no.fint.p360.data.noark.journalstatus.JournalStatusService;
 import no.fint.p360.data.noark.korrespondanseparttype.KorrespondansepartTypeService;
+import no.fint.p360.data.noark.merknadstype.MerknadstypeService;
 import no.fint.p360.data.noark.partrolle.PartRolleService;
 import no.fint.p360.data.noark.saksstatus.SaksStatusService;
 import no.fint.p360.data.noark.tilknyttetregistreringsom.TilknyttetRegistreringSomService;
@@ -46,6 +47,9 @@ public class KodeverkRepository {
     @Autowired
     private TilknyttetRegistreringSomService tilknyttetRegistreringSomService;
 
+    @Autowired
+    private MerknadstypeService merknadstypeService;
+
     @Getter
     private List<SaksstatusResource> saksstatus;
 
@@ -70,6 +74,9 @@ public class KodeverkRepository {
     @Getter
     private List<JournalStatusResource> journalStatus;
 
+    @Getter
+    private List<MerknadstypeResource> merknadstype;
+
     @Scheduled(initialDelay = 10000, fixedDelayString = "${fint.kodeverk.refresh-interval:1500000}")
     public void refresh() {
         saksstatus = saksStatusService.getCaseStatusTable().collect(Collectors.toList());
@@ -80,6 +87,7 @@ public class KodeverkRepository {
         journalStatus = journalStatusService.getJournalStatusTable().collect(Collectors.toList());
         tilknyttetRegistreringSom = tilknyttetRegistreringSomService.getDocumentRelationTable().collect(Collectors.toList());
         partRolle = partRolleService.getPartRolle().collect(Collectors.toList());
+        merknadstype = merknadstypeService.getMerknadstype().collect(Collectors.toList());
         log.info("Refreshed code lists");
     }
 

--- a/src/main/java/no/fint/p360/data/kulturminne/TilskuddFartoyFactory.java
+++ b/src/main/java/no/fint/p360/data/kulturminne/TilskuddFartoyFactory.java
@@ -9,6 +9,7 @@ import no.fint.model.administrasjon.personal.Personalressurs;
 import no.fint.model.felles.kompleksedatatyper.Identifikator;
 import no.fint.model.kultur.kulturminnevern.TilskuddFartoy;
 import no.fint.model.resource.Link;
+import no.fint.model.resource.administrasjon.arkiv.MerknadResource;
 import no.fint.model.resource.administrasjon.arkiv.PartsinformasjonResource;
 import no.fint.model.resource.administrasjon.arkiv.SaksstatusResource;
 import no.fint.model.resource.kultur.kulturminnevern.TilskuddFartoyResource;
@@ -132,6 +133,14 @@ public class TilskuddFartoyFactory {
                 .forEach(arrayOfCaseContactParameter.getCaseContactParameter()::add);
         createCaseParameter.setContacts(objectFactory.createCaseParameterBaseContacts(arrayOfCaseContactParameter));
 
+        ArrayOfRemark arrayOfRemark = objectFactory.createArrayOfRemark();
+        tilskuddFartoy
+                .getMerknad()
+                .stream()
+                .map(this::createCaseRemarkParameter)
+                .forEach(arrayOfRemark.getRemark()::add);
+        createCaseParameter.setRemarks(objectFactory.createCaseParameterBaseRemarks(arrayOfRemark));
+
         /*
         createCaseParameter.setResponsiblePersonIdNumber(
                 objectFactory.createCaseParameterBaseResponsiblePersonIdNumber(
@@ -141,6 +150,24 @@ public class TilskuddFartoyFactory {
         */
 
         return createCaseParameter;
+    }
+
+    private Remark createCaseRemarkParameter(MerknadResource merknadResource) {
+        Remark remark = objectFactory.createRemark();
+        remark.setContent(objectFactory.createRemarkContent(merknadResource.getMerknadstekst()));
+
+        merknadResource
+                .getMerknadstype()
+                .stream()
+                .map(Link::getHref)
+                .filter(StringUtils::isNotBlank)
+                .map(s -> StringUtils.substringAfterLast(s, "/"))
+                .map(s -> StringUtils.prependIfMissing(s, "recno:"))
+                .map(objectFactory::createRemarkRemarkType)
+                .findFirst()
+                .ifPresent(remark::setRemarkType);
+
+        return remark;
     }
 
 

--- a/src/main/java/no/fint/p360/data/noark/journalpost/JournalpostFactory.java
+++ b/src/main/java/no/fint/p360/data/noark/journalpost/JournalpostFactory.java
@@ -132,7 +132,7 @@ public class JournalpostFactory {
                 .map(DocumentCategoryResult::getRecno)
                 .map(String::valueOf)
                 .map(Link.apply(JournalpostType.class, "systemid"))
-                .ifPresent(journalpost::addJournalPostType);
+                .ifPresent(journalpost::addJournalposttype);
         optionalValue(documentResult.getStatusCode())
                 .flatMap(code -> kodeverkRepository
                         .getJournalStatus()
@@ -142,22 +142,15 @@ public class JournalpostFactory {
                 .map(JournalStatusResource::getSystemId)
                 .map(Identifikator::getIdentifikatorverdi)
                 .map(Link.apply(JournalStatus.class, "systemid"))
-                .ifPresent(journalpost::addJournalStatus);
+                .ifPresent(journalpost::addJournalstatus);
 
-        Optional.ofNullable(
+        journalpost.setMerknad(
                 optionalValue(documentResult.getRemarks())
                         .map(ArrayOfRemarkInfo::getRemarkInfo)
                         .map(List::stream)
                         .orElse(Stream.empty())
-                        .map(r -> String.format("%s: %s\n%s\n%s",
-                                r.getTypeCode().getValue(),
-                                r.getTypeDescription().getValue(),
-                                r.getTitle().getValue(),
-                                r.getContent().getValue()))
-                        .peek(log::info)
-                        .collect(Collectors.joining("\n\n")))
-                .filter(StringUtils::isNotBlank)
-                .ifPresent(journalpost::setBeskrivelse);
+                        .map(this::createMerknad)
+                        .collect(Collectors.toList()));
 
         List<DocumentFileResult> documentFileResult = documentResult.getFiles().getValue().getDocumentFileResult();
         List<DokumentbeskrivelseResource> dokumentbeskrivelseResourcesList = new ArrayList<>();
@@ -221,6 +214,36 @@ public class JournalpostFactory {
         return journalpost;
     }
 
+    private MerknadResource createMerknad(RemarkInfo remarkInfo) {
+        MerknadResource merknad = new MerknadResource();
+
+        optionalValue(remarkInfo.getTypeCode())
+                .flatMap(type ->
+                        kodeverkRepository
+                                .getMerknadstype()
+                                .stream()
+                                .filter(v -> StringUtils.equalsIgnoreCase(type, v.getKode()))
+                                .findAny())
+                .map(MerknadstypeResource::getSystemId)
+                .map(Identifikator::getIdentifikatorverdi)
+                .map(Link.apply(Merknadstype.class, "systemid"))
+                .ifPresent(merknad::addMerknadstype);
+
+        merknad.setMerknadstekst(
+                Stream.of(optionalValue(remarkInfo.getTitle()), optionalValue(remarkInfo.getContent()))
+                        .filter(Optional::isPresent)
+                        .map(Optional::get)
+                        .collect(Collectors.joining(" - ")));
+
+        optionalValue(remarkInfo.getModifiedDate())
+                .map(FintUtils::parseDate)
+                .ifPresent(merknad::setMerknadsdato);
+
+        // TODO merknad.addMerknadRegistrertAv();
+
+        return merknad;
+    }
+
     public CreateDocumentParameter toP360(JournalpostResource journalpostResource, String caseNumber) {
 
         CreateDocumentParameter createDocumentParameter = objectFactory.createCreateDocumentParameter();
@@ -235,7 +258,7 @@ public class JournalpostFactory {
 //        createDocumentParameter.setAccessGroup(objectFactory.createDocumentParameterBaseAccessGroup("Public"));
 
         journalpostResource
-                .getJournalPostType()
+                .getJournalposttype()
                 .stream()
                 .map(Link::getHref)
                 .filter(StringUtils::isNotBlank)
@@ -246,7 +269,7 @@ public class JournalpostFactory {
                 .ifPresent(createDocumentParameter::setCategory);
 
         journalpostResource
-                .getJournalStatus()
+                .getJournalstatus()
                 .stream()
                 .map(Link::getHref)
                 .filter(StringUtils::isNotBlank)

--- a/src/main/java/no/fint/p360/data/noark/journalpost/JournalpostFactory.java
+++ b/src/main/java/no/fint/p360/data/noark/journalpost/JournalpostFactory.java
@@ -294,7 +294,35 @@ public class JournalpostFactory {
                 .flatMap(this::createFiles)
                 .forEach(arrayOfCreateFileParameter.getCreateFileParameter()::add);
         createDocumentParameter.setFiles(objectFactory.createDocumentParameterBaseFiles(arrayOfCreateFileParameter));
+
+        ArrayOfRemark arrayOfRemark = objectFactory.createArrayOfRemark();
+        journalpostResource
+                .getMerknad()
+                .stream()
+                .map(this::createDocumentRemarkParameter)
+                .forEach(arrayOfRemark.getRemark()::add);
+        createDocumentParameter.setRemarks(objectFactory.createDocumentParameterBaseRemarks(arrayOfRemark));
+
+
         return createDocumentParameter;
+    }
+
+    private Remark createDocumentRemarkParameter(MerknadResource merknadResource) {
+        Remark remark = objectFactory.createRemark();
+        remark.setContent(objectFactory.createRemarkContent(merknadResource.getMerknadstekst()));
+
+        merknadResource
+                .getMerknadstype()
+                .stream()
+                .map(Link::getHref)
+                .filter(StringUtils::isNotBlank)
+                .map(s -> StringUtils.substringAfterLast(s, "/"))
+                .map(s -> StringUtils.prependIfMissing(s, "recno:"))
+                .map(objectFactory::createRemarkRemarkType)
+                .findFirst()
+                .ifPresent(remark::setRemarkType);
+
+        return remark;
     }
 
 

--- a/src/main/java/no/fint/p360/data/noark/merknadstype/MerknadstypeFactory.java
+++ b/src/main/java/no/fint/p360/data/noark/merknadstype/MerknadstypeFactory.java
@@ -1,0 +1,24 @@
+package no.fint.p360.data.noark.merknadstype;
+
+
+import lombok.extern.slf4j.Slf4j;
+import no.fint.arkiv.p360.support.CodeTableRowResult;
+import no.fint.model.resource.administrasjon.arkiv.MerknadstypeResource;
+import no.fint.p360.data.utilities.FintUtils;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class MerknadstypeFactory {
+
+    public MerknadstypeResource toFintResource(CodeTableRowResult codeTableRow) {
+        MerknadstypeResource merknadstypeResource = new MerknadstypeResource();
+
+        merknadstypeResource.setSystemId(FintUtils.createIdentifikator(codeTableRow.getRecno().toString()));
+        merknadstypeResource.setKode(codeTableRow.getCode().getValue());
+        merknadstypeResource.setNavn(codeTableRow.getDescription().getValue());
+
+        return merknadstypeResource;
+
+    }
+}

--- a/src/main/java/no/fint/p360/data/noark/merknadstype/MerknadstypeService.java
+++ b/src/main/java/no/fint/p360/data/noark/merknadstype/MerknadstypeService.java
@@ -1,0 +1,29 @@
+package no.fint.p360.data.noark.merknadstype;
+
+import lombok.extern.slf4j.Slf4j;
+import no.fint.model.resource.administrasjon.arkiv.MerknadstypeResource;
+import no.fint.p360.data.p360.P360SupportService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.stream.Stream;
+
+@Slf4j
+@Service
+public class MerknadstypeService {
+
+    @Autowired
+    private P360SupportService supportService;
+
+    @Autowired
+    private MerknadstypeFactory factory;
+
+    @Value("${fint.p360.tables.note-type:code table: Note type}")
+    private String codeTableName;
+
+    public Stream<MerknadstypeResource> getMerknadstype() {
+        return supportService.getCodeTableRowResultStream(codeTableName)
+                .map(factory::toFintResource);
+    }
+}

--- a/src/main/java/no/fint/p360/service/EventHandlerService.java
+++ b/src/main/java/no/fint/p360/service/EventHandlerService.java
@@ -163,6 +163,9 @@ public class EventHandlerService {
                 case GET_ALL_JOURNALPOSTTYPE:
                     onGetAllJournalpostType(response);
                     break;
+                case GET_ALL_MERKNADSTYPE:
+                    onGetAllMerknadstype(response);
+                    break;
                 case GET_SAK:
                     onGetSak(event.getQuery(), response);
                     break;
@@ -324,6 +327,11 @@ public class EventHandlerService {
 
     private void onGetSaksstatus(Event<FintLinks> response) {
         kodeverkRepository.getSaksstatus().forEach(response::addData);
+        response.setResponseStatus(ResponseStatus.ACCEPTED);
+    }
+
+    private void onGetAllMerknadstype(Event<FintLinks> response) {
+        kodeverkRepository.getMerknadstype().forEach(response::addData);
         response.setResponseStatus(ResponseStatus.ACCEPTED);
     }
 


### PR DESCRIPTION
Adds support for `Merknadstype` code list, and `merknad` on `Mappe` and `Journalpost`.

Note that NOARK supports Merknad also on `Dokumentbeskrivelse`, but this is not supported by Public 360.

Furthermore, Merknad on `Mappe` is write-only, as the SIF API does not support reading back remarks on case level.