### PR TITLE
Handle WSDL location at runtime.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,6 @@ FROM gcr.io/distroless/java
 ENV JAVA_TOOL_OPTIONS -XX:+ExitOnOutOfMemoryError
 COPY --from=builder /home/gradle/build/deps/external/*.jar /data/
 COPY --from=builder /home/gradle/build/deps/fint/*.jar /data/
+COPY --from=builder /home/gradle/src/main/resources/wsdl/*.wsdl /data/
 COPY --from=builder /home/gradle/build/libs/fint-p360-arkiv-adapter-*.jar /data/fint-p360-arkiv-adapter.jar
 CMD ["/data/fint-p360-arkiv-adapter.jar"]

--- a/k8s-beta.yaml
+++ b/k8s-beta.yaml
@@ -54,6 +54,7 @@ spec:
             - {name: fint.oauth.client-secret, valueFrom: {secretKeyRef: {name: ra-p360-adapter, key: client-secret}}}
             - {name: fint.oauth.scope, value: 'fint-client'}
             - {name: fint.adapter.reject-unknown-events, value: 'false'}
+            - {name: fint.p360.wsdl-location, value: '/data'}
             - {name: fint.p360.user, valueFrom: {secretKeyRef: {name: ra-p360-adapter, key: p360-user}}}
             - {name: fint.p360.password, valueFrom: {secretKeyRef: {name: ra-p360-adapter, key: p360-password}}}
             - {name: fint.p360.endpoint-base-url, valueFrom: {secretKeyRef: {name: ra-p360-adapter, key: p360-endpoint-base-url}}}

--- a/src/main/java/no/fint/p360/data/p360/P360CaseService.java
+++ b/src/main/java/no/fint/p360/data/p360/P360CaseService.java
@@ -6,10 +6,14 @@ import no.fint.p360.data.exception.CreateCaseException;
 import no.fint.p360.data.exception.GetTilskuddFartoyException;
 import no.fint.p360.data.exception.GetTilskuddFartoyNotFoundException;
 import no.fint.p360.data.utilities.Constants;
+import no.fint.p360.data.utilities.P360Utils;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.PostConstruct;
 import javax.xml.ws.WebServiceException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.List;
 import java.util.Map;
 
@@ -22,14 +26,18 @@ public class P360CaseService extends P360AbstractService {
 
     private ObjectFactory objectFactory;
 
+    @Value("${fint.p360.wsdl-location:./src/main/resources/wsdl}/CaseService.wsdl")
+    private String wsdlLocation;
 
     public P360CaseService() {
         super("http://software-innovation.com/SI.Data", "CaseService");
     }
 
     @PostConstruct
-    public void init() {
-        caseServicePort = new CaseService(CaseService.WSDL_LOCATION, serviceName).getBasicHttpBindingICaseService();
+    public void init() throws MalformedURLException {
+        URL wsdlLocationUrl = P360Utils.getURL(wsdlLocation);
+        log.info("WSDL location: {}", wsdlLocationUrl);
+        caseServicePort = new CaseService(wsdlLocationUrl, serviceName).getBasicHttpBindingICaseService();
         super.setup(caseServicePort, "CaseService");
 
         objectFactory = new ObjectFactory();

--- a/src/main/java/no/fint/p360/data/p360/P360ContactService.java
+++ b/src/main/java/no/fint/p360/data/p360/P360ContactService.java
@@ -6,11 +6,15 @@ import no.fint.p360.data.exception.CreateContactException;
 import no.fint.p360.data.exception.CreateEnterpriseException;
 import no.fint.p360.data.exception.EnterpriseNotFound;
 import no.fint.p360.data.exception.PrivatePersonNotFound;
+import no.fint.p360.data.utilities.P360Utils;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.PostConstruct;
 import javax.xml.namespace.QName;
 import javax.xml.ws.WebServiceException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -23,14 +27,18 @@ public class P360ContactService extends P360AbstractService {
     private IContactService contactService;
     private ObjectFactory objectFactory;
 
+    @Value("${fint.p360.wsdl-location:./src/main/resources/wsdl}/ContactService.wsdl")
+    private String wsdlLocation;
+
     public P360ContactService() {
         super("http://software-innovation.com/SI.Data", "ContactService");
     }
 
     @PostConstruct
-    private void init() {
-
-        contactService = new ContactService(ContactService.WSDL_LOCATION, SERVICE_NAME).getBasicHttpBindingIContactService();
+    private void init() throws MalformedURLException {
+        URL wsdlLocationUrl = P360Utils.getURL(wsdlLocation);
+        log.info("WSDL location: {}", wsdlLocationUrl);
+        contactService = new ContactService(wsdlLocationUrl, SERVICE_NAME).getBasicHttpBindingIContactService();
         super.setup(contactService, "ContactService");
 
         objectFactory = new ObjectFactory();

--- a/src/main/java/no/fint/p360/data/p360/P360DocumentService.java
+++ b/src/main/java/no/fint/p360/data/p360/P360DocumentService.java
@@ -4,10 +4,14 @@ import lombok.extern.slf4j.Slf4j;
 import no.fint.arkiv.p360.document.*;
 import no.fint.p360.data.exception.CreateDocumentException;
 import no.fint.p360.data.exception.GetDocumentException;
+import no.fint.p360.data.utilities.P360Utils;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.PostConstruct;
 import javax.xml.ws.WebServiceException;
+import java.net.MalformedURLException;
+import java.net.URL;
 
 @Service
 @Slf4j
@@ -16,14 +20,18 @@ public class P360DocumentService extends P360AbstractService {
     private IDocumentService documentService;
     private ObjectFactory objectFactory;
 
+    @Value("${fint.p360.wsdl-location:./src/main/resources/wsdl}/DocumentService.wsdl")
+    private String wsdlLocation;
+
     public P360DocumentService() {
         super("http://software-innovation.com/SI.Data", "DocumentService");
     }
 
     @PostConstruct
-    private void init() {
-
-        documentService = new DocumentService(DocumentService.WSDL_LOCATION, serviceName).getBasicHttpBindingIDocumentService();
+    private void init() throws MalformedURLException {
+        URL wsdlLocationUrl = P360Utils.getURL(wsdlLocation);
+        log.info("WSDL location: {}", wsdlLocationUrl);
+        documentService = new DocumentService(wsdlLocationUrl, serviceName).getBasicHttpBindingIDocumentService();
         super.setup(documentService, "DocumentService");
 
         objectFactory = new ObjectFactory();

--- a/src/main/java/no/fint/p360/data/p360/P360FileService.java
+++ b/src/main/java/no/fint/p360/data/p360/P360FileService.java
@@ -4,12 +4,16 @@ import lombok.extern.slf4j.Slf4j;
 import no.fint.arkiv.p360.file.*;
 import no.fint.p360.AdapterProps;
 import no.fint.p360.data.exception.FileNotFound;
+import no.fint.p360.data.utilities.P360Utils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.PostConstruct;
 import javax.xml.namespace.QName;
 import javax.xml.ws.WebServiceException;
+import java.net.MalformedURLException;
+import java.net.URL;
 
 @Slf4j
 @Service
@@ -24,14 +28,18 @@ public class P360FileService extends P360AbstractService {
     @Autowired
     private AdapterProps props;
 
+    @Value("${fint.p360.wsdl-location:./src/main/resources/wsdl}/FileService.wsdl")
+    private String wsdlLocation;
+
     public P360FileService() {
         super("http://software-innovation.com/SI.Data", "FileService");
     }
 
     @PostConstruct
-    private void init() {
-
-        fileServicePort = new FileService(FileService.WSDL_LOCATION, SERVICE_NAME).getBasicHttpBindingIFileService();
+    private void init() throws MalformedURLException {
+        URL wsdlLocationUrl = P360Utils.getURL(wsdlLocation);
+        log.info("WSDL location: {}", wsdlLocationUrl);
+        fileServicePort = new FileService(wsdlLocationUrl, SERVICE_NAME).getBasicHttpBindingIFileService();
         objectFactory = new ObjectFactory();
 
     }

--- a/src/main/java/no/fint/p360/data/p360/P360SupportService.java
+++ b/src/main/java/no/fint/p360/data/p360/P360SupportService.java
@@ -4,11 +4,15 @@ import lombok.extern.slf4j.Slf4j;
 import no.fint.arkiv.p360.support.*;
 import no.fint.p360.data.exception.CodeTableNotFound;
 import no.fint.p360.data.utilities.FintUtils;
+import no.fint.p360.data.utilities.P360Utils;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.PostConstruct;
 import javax.xml.namespace.QName;
 import javax.xml.ws.WebServiceException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -21,13 +25,18 @@ public class P360SupportService extends P360AbstractService {
     private ISupportService supportService;
     private ObjectFactory objectFactory;
 
+    @Value("${fint.p360.wsdl-location:./src/main/resources/wsdl}/SupportService.wsdl")
+    private String wsdlLocation;
+
     public P360SupportService() {
         super("http://software-innovation.com/SI.Data", "SupportService");
     }
 
     @PostConstruct
-    private void init() {
-        supportService = new SupportService(SupportService.WSDL_LOCATION, SERVICE_NAME).getBasicHttpBindingISupportService();
+    private void init() throws MalformedURLException {
+        URL wsdlLocationUrl = P360Utils.getURL(wsdlLocation);
+        log.info("WSDL location: {}", wsdlLocationUrl);
+        supportService = new SupportService(wsdlLocationUrl, SERVICE_NAME).getBasicHttpBindingISupportService();
         super.setup(supportService, "SupportService");
         objectFactory = new ObjectFactory();
     }

--- a/src/main/java/no/fint/p360/data/utilities/P360Utils.java
+++ b/src/main/java/no/fint/p360/data/utilities/P360Utils.java
@@ -6,6 +6,8 @@ import no.fint.model.resource.Link;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.xml.bind.JAXBElement;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -20,6 +22,13 @@ public enum P360Utils {
         keywords.forEach(keywordArray.getString()::add);
 
         return objectFactory.createCaseParameterBaseKeywords(keywordArray);
+    }
+
+    public static URL getURL(String location) throws MalformedURLException {
+        if (StringUtils.startsWithAny(location, "file:", "http:", "https:")) {
+            return new URL(location);
+        }
+        return new URL("file:" + location);
     }
 
     public static JAXBElement<ExternalIdParameter> getExternalIdParameter(Identifikator id) {


### PR DESCRIPTION
Running the service in a container fails due to the location of the WSDL files not being available runtime.

Updated to make WSDL location configurable, and copying the WSDLs to the target image.