### PR TITLE
Extract interfaces to be implemented by RPC as well.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ generated-sources
 /.settings/
 /bin/
 /.vscode/
+src/main/resources/application-*.properties

--- a/src/main/java/no/fint/p360/TestController.java
+++ b/src/main/java/no/fint/p360/TestController.java
@@ -21,6 +21,11 @@ public class TestController {
     @Autowired
     private P360AccessGroupService accessGroupService;
 
+    @GetMapping(value = "version", produces = MediaType.APPLICATION_JSON_VALUE)
+    public String getVersion() {
+        return supportService.getSIFVersion();
+    }
+
     @GetMapping(value = "codelist", produces = MediaType.APPLICATION_JSON_VALUE)
     public String getCodelist(@RequestParam String id) throws JsonProcessingException {
         return new ObjectMapper().writeValueAsString(supportService.getCodeTable(id));

--- a/src/main/java/no/fint/p360/data/p360/P360AccessGroupService.java
+++ b/src/main/java/no/fint/p360/data/p360/P360AccessGroupService.java
@@ -1,55 +1,10 @@
 package no.fint.p360.data.p360;
 
-import lombok.extern.slf4j.Slf4j;
-import no.fint.arkiv.p360.accessgroup.*;
-import no.fint.p360.data.utilities.P360Utils;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
+import no.fint.arkiv.p360.accessgroup.GetAccessGroupsQuery;
+import no.fint.arkiv.p360.accessgroup.GetAccessGroupsResult;
 
-import javax.annotation.PostConstruct;
-import javax.xml.namespace.QName;
-import javax.xml.ws.WebServiceException;
-import java.net.MalformedURLException;
-import java.net.URL;
+public interface P360AccessGroupService {
+    GetAccessGroupsResult getAccessGroups(GetAccessGroupsQuery parameter);
 
-@Slf4j
-@Service
-public class P360AccessGroupService extends P360AbstractService {
-
-    private static final QName SERVICE_NAME = new QName("http://software-innovation.com/SI.Data", "AccessGroupService");
-
-    private IAccessGroupService accessGroupService;
-    private ObjectFactory objectFactory;
-
-    @Value("${fint.p360.wsdl-location:./src/main/resources/wsdl}/AccessGroupService.wsdl")
-    private String wsdlLocation;
-
-    public P360AccessGroupService() {
-        super("http://software-innovation.com/SI.Data", "AccessGroupService");
-    }
-
-    @PostConstruct
-    private void init() throws MalformedURLException {
-        URL wsdlLocationUrl = P360Utils.getURL(wsdlLocation);
-        log.info("WSDL location: {}", wsdlLocationUrl);
-        accessGroupService = new AccessGroupService(wsdlLocationUrl, SERVICE_NAME).getBasicHttpBindingIAccessGroupService();
-        super.setup(accessGroupService, "AccessGroupService");
-        objectFactory = new ObjectFactory();
-    }
-
-    public GetAccessGroupsResult getAccessGroups(GetAccessGroupsQuery parameter) {
-        return accessGroupService.getAccessGroups(parameter);
-    }
-
-    public boolean ping() {
-
-        try {
-            accessGroupService.ping();
-        } catch (WebServiceException e) {
-            return false;
-        }
-
-        return true;
-    }
-
+    boolean ping();
 }

--- a/src/main/java/no/fint/p360/data/p360/P360CaseService.java
+++ b/src/main/java/no/fint/p360/data/p360/P360CaseService.java
@@ -1,123 +1,24 @@
 package no.fint.p360.data.p360;
 
-import lombok.extern.slf4j.Slf4j;
-import no.fint.arkiv.p360.caze.*;
+import no.fint.arkiv.p360.caze.CaseResult;
+import no.fint.arkiv.p360.caze.CreateCaseParameter;
 import no.fint.p360.data.exception.CreateCaseException;
 import no.fint.p360.data.exception.GetTilskuddFartoyException;
 import no.fint.p360.data.exception.GetTilskuddFartoyNotFoundException;
-import no.fint.p360.data.utilities.Constants;
-import no.fint.p360.data.utilities.P360Utils;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
 
-import javax.annotation.PostConstruct;
-import javax.xml.ws.WebServiceException;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.List;
 import java.util.Map;
 
-@Service
-@Slf4j
-public class P360CaseService extends P360AbstractService {
+public interface P360CaseService {
+    boolean ping();
 
+    String createCase(CreateCaseParameter createCaseParameter) throws CreateCaseException;
 
-    private ICaseService caseServicePort;
+    CaseResult getSakByCaseNumber(String caseNumber) throws GetTilskuddFartoyNotFoundException, GetTilskuddFartoyException;
 
-    private ObjectFactory objectFactory;
+    CaseResult getSakBySystemId(String systemId) throws GetTilskuddFartoyNotFoundException, GetTilskuddFartoyException;
 
-    @Value("${fint.p360.wsdl-location:./src/main/resources/wsdl}/CaseService.wsdl")
-    private String wsdlLocation;
+    CaseResult getSakByExternalId(String externalId) throws GetTilskuddFartoyNotFoundException, GetTilskuddFartoyException;
 
-    public P360CaseService() {
-        super("http://software-innovation.com/SI.Data", "CaseService");
-    }
-
-    @PostConstruct
-    public void init() throws MalformedURLException {
-        URL wsdlLocationUrl = P360Utils.getURL(wsdlLocation);
-        log.info("WSDL location: {}", wsdlLocationUrl);
-        caseServicePort = new CaseService(wsdlLocationUrl, serviceName).getBasicHttpBindingICaseService();
-        super.setup(caseServicePort, "CaseService");
-
-        objectFactory = new ObjectFactory();
-    }
-
-    public boolean ping() {
-        try {
-            caseServicePort.ping();
-        } catch (WebServiceException e) {
-            return false;
-        }
-
-        return true;
-    }
-
-
-    public String createCase(CreateCaseParameter createCaseParameter) throws CreateCaseException {
-        log.info("Create case: {}", createCaseParameter);
-        CaseOperationResult operationResult = caseServicePort.createCase(createCaseParameter);
-        log.info("Create case result: {}", operationResult);
-        if (operationResult.isSuccessful()) {
-            return operationResult.getCaseNumber().getValue();
-        } else {
-            throw new CreateCaseException(operationResult.getErrorDetails().getValue());
-        }
-    }
-
-    public CaseResult getSakByCaseNumber(String caseNumber) throws GetTilskuddFartoyNotFoundException, GetTilskuddFartoyException {
-        GetCasesQuery getCasesQuery = new GetCasesQuery();
-        getCasesQuery.setCaseNumber(objectFactory.createGetCasesQueryCaseNumber(caseNumber));
-        return getCase(getCasesQuery);
-    }
-
-    public CaseResult getSakBySystemId(String systemId) throws GetTilskuddFartoyNotFoundException, GetTilskuddFartoyException {
-        GetCasesQuery getCasesQuery = new GetCasesQuery();
-        getCasesQuery.setRecno(objectFactory.createGetCasesQueryRecno(Integer.valueOf(systemId)));
-        return getCase(getCasesQuery);
-    }
-
-    public CaseResult getSakByExternalId(String externalId) throws GetTilskuddFartoyNotFoundException, GetTilskuddFartoyException {
-        GetCasesQuery getCasesQuery = objectFactory.createGetCasesQuery();
-        ExternalIdParameter externalIdParameter = objectFactory.createExternalIdParameter();
-        externalIdParameter.setType(objectFactory.createExternalIdParameterType(Constants.EXTERNAL_ID_TYPE));
-        externalIdParameter.setId(objectFactory.createExternalIdParameterId(externalId));
-        getCasesQuery.setExternalId(objectFactory.createGetCasesQueryExternalId(externalIdParameter));
-        return getCase(getCasesQuery);
-    }
-
-    public List<CaseResult> getGetCasesQueryByTitle(Map<String, String> params) throws GetTilskuddFartoyException {
-        GetCasesQuery getCasesQuery = new GetCasesQuery();
-        getCasesQuery.setTitle(objectFactory.createGetCasesQueryTitle(String.format("%%%s%%", params.get("title"))));
-        getCasesQuery.setMaxReturnedCases(objectFactory.createGetCasesQueryMaxReturnedCases(Integer.valueOf(params.getOrDefault("maxResult", "10"))));
-        getCasesQuery.setIncludeCustomFields(Boolean.TRUE);
-        return getCases(getCasesQuery);
-    }
-
-    private List<CaseResult> getCases(GetCasesQuery casesQuery) throws GetTilskuddFartoyException {
-        GetCasesResult cases = caseServicePort.getCases(casesQuery);
-
-        if (cases.isSuccessful()) {
-            return cases.getCases().getValue().getCaseResult();
-        }
-        throw new GetTilskuddFartoyException(cases.getErrorDetails().getValue());
-    }
-
-    private CaseResult getCase(GetCasesQuery casesQuery) throws GetTilskuddFartoyNotFoundException, GetTilskuddFartoyException {
-        casesQuery.setIncludeCustomFields(Boolean.TRUE);
-        casesQuery.setIncludeCaseContacts(Boolean.TRUE);
-        log.info("Query: {}", casesQuery);
-        GetCasesResult cases = caseServicePort.getCases(casesQuery);
-        log.info("Cases: {}", cases);
-
-        if (cases.isSuccessful() && cases.getTotalPageCount().getValue() == 1) {
-            return cases.getCases().getValue().getCaseResult().get(0);
-        }
-        if (cases.getTotalPageCount().getValue() != 1) {
-            throw new GetTilskuddFartoyNotFoundException("Case could not be found");
-        }
-        throw new GetTilskuddFartoyException(cases.getErrorDetails().getValue());
-    }
-
-
+    List<CaseResult> getGetCasesQueryByTitle(Map<String, String> params) throws GetTilskuddFartoyException;
 }

--- a/src/main/java/no/fint/p360/data/p360/P360ContactService.java
+++ b/src/main/java/no/fint/p360/data/p360/P360ContactService.java
@@ -1,222 +1,34 @@
 package no.fint.p360.data.p360;
 
-import lombok.extern.slf4j.Slf4j;
 import no.fint.arkiv.p360.contact.*;
 import no.fint.p360.data.exception.CreateContactException;
 import no.fint.p360.data.exception.CreateEnterpriseException;
 import no.fint.p360.data.exception.EnterpriseNotFound;
 import no.fint.p360.data.exception.PrivatePersonNotFound;
-import no.fint.p360.data.utilities.P360Utils;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
 
-import javax.annotation.PostConstruct;
-import javax.xml.namespace.QName;
-import javax.xml.ws.WebServiceException;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.Map;
 import java.util.stream.Stream;
 
-@Slf4j
-@Service
-public class P360ContactService extends P360AbstractService {
+public interface P360ContactService {
+    PrivatePersonResult getPrivatePersonByRecno(int recNo);
 
-    private static final QName SERVICE_NAME = new QName("http://software-innovation.com/SI.Data", "ContactService");
+    PrivatePersonResult getPrivatePersonByPersonalIdNumber(String personalIdNumber) throws PrivatePersonNotFound;
 
-    private IContactService contactService;
-    private ObjectFactory objectFactory;
+    ContactPersonResult getContactPersonByRecno(int recNo);
 
-    @Value("${fint.p360.wsdl-location:./src/main/resources/wsdl}/ContactService.wsdl")
-    private String wsdlLocation;
+    EnterpriseResult getEnterpriseByRecno(int recNo);
 
-    public P360ContactService() {
-        super("http://software-innovation.com/SI.Data", "ContactService");
-    }
+    EnterpriseResult getEnterpriseByEnterpriseNumber(String enterpriseNumber) throws EnterpriseNotFound;
 
-    @PostConstruct
-    private void init() throws MalformedURLException {
-        URL wsdlLocationUrl = P360Utils.getURL(wsdlLocation);
-        log.info("WSDL location: {}", wsdlLocationUrl);
-        contactService = new ContactService(wsdlLocationUrl, SERVICE_NAME).getBasicHttpBindingIContactService();
-        super.setup(contactService, "ContactService");
+    boolean ping();
 
-        objectFactory = new ObjectFactory();
-    }
+    Stream<EnterpriseResult> searchEnterprise(Map<String, String> queryParams);
 
-    public PrivatePersonResult getPrivatePersonByRecno(int recNo) {
-        GetPrivatePersonsParameter getPrivatePersonsParameter = new GetPrivatePersonsParameter();
-        getPrivatePersonsParameter.setIncludeCustomFields(Boolean.TRUE);
-        getPrivatePersonsParameter.setRecno(objectFactory.createGetPrivatePersonsParameterRecno(recNo));
-        GetPrivatePersonsResult privatePersons = contactService.getPrivatePersons(getPrivatePersonsParameter);
+    Stream<PrivatePersonResult> searchPrivatePerson(Map<String, String> queryParams);
 
-        log.info("PrivatePersonsResult: {}", privatePersons);
+    Stream<ContactPersonResult> searchContactPerson(Map<String, String> queryParams);
 
-        if (privatePersons.isSuccessful() && privatePersons.getTotalPageCount().getValue() == 1) {
-            return privatePersons.getPrivatePersons().getValue().getPrivatePersonResult().get(0);
-        }
-        return null;
-    }
+    Integer createPrivatePerson(SynchronizePrivatePersonParameter privatePerson) throws CreateContactException;
 
-    public PrivatePersonResult getPrivatePersonByPersonalIdNumber(String personalIdNumber) throws PrivatePersonNotFound {
-        GetPrivatePersonsParameter getPrivatePersonsParameter = objectFactory.createGetPrivatePersonsParameter();
-        getPrivatePersonsParameter.setIncludeCustomFields(Boolean.TRUE);
-
-        getPrivatePersonsParameter.setPersonalIdNumber(
-                objectFactory.createGetPrivatePersonsParameterPersonalIdNumber(personalIdNumber));
-
-        GetPrivatePersonsResult privatePersons = contactService.getPrivatePersons(getPrivatePersonsParameter);
-
-        log.info("PrivatePersonsResult: {}", privatePersons);
-
-        if (privatePersons.isSuccessful() && privatePersons.getTotalPageCount().getValue() == 1) {
-            return privatePersons.getPrivatePersons().getValue().getPrivatePersonResult().get(0);
-        }
-
-        throw new PrivatePersonNotFound(privatePersons.getErrorMessage().getValue());
-    }
-
-    public ContactPersonResult getContactPersonByRecno(int recNo) {
-
-        GetContactPersonsParameter getContactPersonsParameter = new GetContactPersonsParameter();
-        getContactPersonsParameter.setIncludeCustomFields(Boolean.TRUE);
-        getContactPersonsParameter.setRecno(objectFactory.createGetContactPersonsParameterRecno(recNo));
-        GetContactPersonsResult contactPersons = contactService.getContactPersons(getContactPersonsParameter);
-
-        log.info("ContactPersonsResult: {}", contactPersons);
-
-        if (contactPersons.isSuccessful() && contactPersons.getTotalPageCount().getValue() == 1) {
-            return contactPersons.getContactPersons().getValue().getContactPersonResult().get(0);
-        }
-        return null;
-    }
-
-    public EnterpriseResult getEnterpriseByRecno(int recNo) {
-
-        GetEnterprisesParameter getEnterpriseParameter = new GetEnterprisesParameter();
-        getEnterpriseParameter.setIncludeCustomFields(Boolean.TRUE);
-        getEnterpriseParameter.setRecno(objectFactory.createGetEnterprisesParameterRecno(recNo));
-        GetEnterprisesResult enterprises = contactService.getEnterprises(getEnterpriseParameter);
-
-        log.info("EnterpriseResult: {}", enterprises);
-
-        if (enterprises.isSuccessful() && enterprises.getTotalPageCount().getValue() == 1) {
-            return enterprises.getEnterprises().getValue().getEnterpriseResult().get(0);
-        }
-
-        return null;
-    }
-
-    public EnterpriseResult getEnterpriseByEnterpriseNumber(String enterpriseNumber) throws EnterpriseNotFound {
-        GetEnterprisesParameter getEnterprisesParameter = objectFactory.createGetEnterprisesParameter();
-        getEnterprisesParameter.setIncludeCustomFields(Boolean.TRUE);
-        getEnterprisesParameter.setEnterpriseNumber(objectFactory.createGetEnterprisesParameterEnterpriseNumber(enterpriseNumber));
-
-        GetEnterprisesResult enterprises = contactService.getEnterprises(getEnterprisesParameter);
-
-        log.info("EnterpriseResult: {}", enterprises);
-
-        if (enterprises.isSuccessful() && enterprises.getTotalPageCount().getValue() == 1) {
-            return enterprises.getEnterprises().getValue().getEnterpriseResult().get(0);
-        }
-
-        throw new EnterpriseNotFound(enterprises.getErrorMessage().getValue());
-    }
-
-    public boolean ping() {
-
-        try {
-            contactService.ping();
-        } catch (WebServiceException e) {
-            return false;
-        }
-
-        return true;
-    }
-
-    public Stream<EnterpriseResult> searchEnterprise(Map<String, String> queryParams) {
-        GetEnterprisesParameter getEnterprisesParameter = objectFactory.createGetEnterprisesParameter();
-        if (queryParams.containsKey("navn")) {
-            getEnterprisesParameter.setName(objectFactory.createGetEnterprisesParameterName(queryParams.get("navn")));
-        }
-        if (queryParams.containsKey("organisasjonsnummer")) {
-            getEnterprisesParameter.setEnterpriseNumber(objectFactory.createGetEnterprisesParameterEnterpriseNumber(queryParams.get("organisasjonsnummer")));
-        }
-        if (queryParams.containsKey("maxResults")) {
-            getEnterprisesParameter.setMaxRows(objectFactory.createGetEnterprisesParameterMaxRows(Integer.valueOf(queryParams.get("maxResults"))));
-        }
-
-        log.info("GetEnterprises query: {}", getEnterprisesParameter);
-        GetEnterprisesResult result = contactService.getEnterprises(getEnterprisesParameter);
-        log.info("GetEnterprises result: {}", result);
-
-        if (!result.isSuccessful()) {
-            return Stream.empty();
-        }
-
-        return result.getEnterprises().getValue().getEnterpriseResult().stream();
-    }
-
-    public Stream<PrivatePersonResult> searchPrivatePerson(Map<String, String> queryParams) {
-        GetPrivatePersonsParameter getPrivatePersonsParameter = objectFactory.createGetPrivatePersonsParameter();
-        if (queryParams.containsKey("navn")) {
-            getPrivatePersonsParameter.setName(objectFactory.createGetPrivatePersonsParameterName(queryParams.get("navn")));
-        }
-        if (queryParams.containsKey("maxResults")) {
-            getPrivatePersonsParameter.setMaxRows(objectFactory.createGetPrivatePersonsParameterMaxRows(Integer.valueOf(queryParams.get("maxResults"))));
-        }
-
-        log.info("GetPrivatePersons query: {}", getPrivatePersonsParameter);
-        GetPrivatePersonsResult result = contactService.getPrivatePersons(getPrivatePersonsParameter);
-        log.info("GetPrivatePersons: {}", result);
-
-        if (!result.isSuccessful()) {
-            return Stream.empty();
-        }
-
-        return result.getPrivatePersons().getValue().getPrivatePersonResult().stream();
-    }
-
-    public Stream<ContactPersonResult> searchContactPerson(Map<String, String> queryParams) {
-        GetContactPersonsParameter getContactPersonsParameter = objectFactory.createGetContactPersonsParameter();
-
-        if (queryParams.containsKey("navn")) {
-            getContactPersonsParameter.setName(objectFactory.createGetPrivatePersonsParameterName(queryParams.get("navn")));
-        }
-        if (queryParams.containsKey("maxResults")) {
-            getContactPersonsParameter.setMaxRows(objectFactory.createGetPrivatePersonsParameterMaxRows(Integer.valueOf(queryParams.get("maxResults"))));
-        }
-
-        log.info("GetContactPersons query: {}", getContactPersonsParameter);
-        GetContactPersonsResult result = contactService.getContactPersons(getContactPersonsParameter);
-        log.info("GetContactPersons result: {}", result);
-
-        if (!result.isSuccessful()) {
-            return Stream.empty();
-        }
-
-        return result.getContactPersons().getValue().getContactPersonResult().stream();
-    }
-
-    public Integer createPrivatePerson(SynchronizePrivatePersonParameter privatePerson) throws CreateContactException {
-        log.info("Create Private Person: {}", privatePerson);
-        SynchronizePrivatePersonResult privatePersonResult = contactService.synchronizePrivatePerson(privatePerson);
-        log.info("Private Person Result: {}", privatePersonResult);
-        if (privatePersonResult.isSuccessful()) {
-            return privatePersonResult.getRecno();
-        }
-        throw new CreateContactException(privatePersonResult.getErrorMessage().getValue());
-    }
-
-    public Integer createEnterprise(SynchronizeEnterpriseParameter enterprise) throws CreateEnterpriseException {
-        log.info("Create Enterprise: {}", enterprise);
-        SynchronizeEnterpriseResult result = contactService.synchronizeEnterprise(enterprise);
-        log.info("Enterprise Result: {}", result);
-        if (result.isSuccessful()) {
-            return result.getRecno();
-        }
-        throw new CreateEnterpriseException(result.getErrorMessage().getValue());
-    }
-
+    Integer createEnterprise(SynchronizeEnterpriseParameter enterprise) throws CreateEnterpriseException;
 }
-

--- a/src/main/java/no/fint/p360/data/p360/P360DocumentService.java
+++ b/src/main/java/no/fint/p360/data/p360/P360DocumentService.java
@@ -1,80 +1,14 @@
 package no.fint.p360.data.p360;
 
-import lombok.extern.slf4j.Slf4j;
-import no.fint.arkiv.p360.document.*;
+import no.fint.arkiv.p360.document.CreateDocumentParameter;
+import no.fint.arkiv.p360.document.DocumentResult;
 import no.fint.p360.data.exception.CreateDocumentException;
 import no.fint.p360.data.exception.GetDocumentException;
-import no.fint.p360.data.utilities.P360Utils;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
 
-import javax.annotation.PostConstruct;
-import javax.xml.ws.WebServiceException;
-import java.net.MalformedURLException;
-import java.net.URL;
+public interface P360DocumentService {
+    void createDocument(CreateDocumentParameter createDocumentParameter) throws CreateDocumentException;
 
-@Service
-@Slf4j
-public class P360DocumentService extends P360AbstractService {
+    DocumentResult getDocumentBySystemId(String systemId) throws GetDocumentException;
 
-    private IDocumentService documentService;
-    private ObjectFactory objectFactory;
-
-    @Value("${fint.p360.wsdl-location:./src/main/resources/wsdl}/DocumentService.wsdl")
-    private String wsdlLocation;
-
-    public P360DocumentService() {
-        super("http://software-innovation.com/SI.Data", "DocumentService");
-    }
-
-    @PostConstruct
-    private void init() throws MalformedURLException {
-        URL wsdlLocationUrl = P360Utils.getURL(wsdlLocation);
-        log.info("WSDL location: {}", wsdlLocationUrl);
-        documentService = new DocumentService(wsdlLocationUrl, serviceName).getBasicHttpBindingIDocumentService();
-        super.setup(documentService, "DocumentService");
-
-        objectFactory = new ObjectFactory();
-    }
-
-    public void createDocument(CreateDocumentParameter createDocumentParameter) throws CreateDocumentException {
-        log.info("Create Document: {}", createDocumentParameter);
-        DocumentOperationResult documentOperationResult = documentService.createDocument(createDocumentParameter);
-        log.info("Create Document Result: {}", documentOperationResult);
-        if (documentOperationResult.isSuccessful()) {
-            log.info("Documents successfully created");
-            return;
-        }
-        throw new CreateDocumentException(documentOperationResult.getErrorMessage().getValue());
-    }
-
-    public DocumentResult getDocumentBySystemId(String systemId) throws GetDocumentException {
-        GetDocumentsQuery documentsQuery = new GetDocumentsQuery();
-        documentsQuery.setRecno(objectFactory.createGetDocumentsQueryRecno(Integer.valueOf(systemId)));
-        documentsQuery.setIncludeRemarks(Boolean.TRUE);
-        documentsQuery.setIncludeCustomFields(Boolean.TRUE);
-
-        GetDocumentsResult documentsResult = documentService.getDocuments(documentsQuery);
-
-        log.info("DocumentsResult: {}", documentsResult);
-
-        if (documentsResult.isSuccessful() && documentsResult.getTotalPageCount().getValue() == 1) {
-            return documentsResult.getDocuments().getValue().getDocumentResult().get(0);
-        }
-        if (documentsResult.getTotalPageCount().getValue() != 1) {
-            throw new GetDocumentException("Document could not be found");
-        }
-        throw new GetDocumentException(documentsResult.getErrorDetails().getValue());
-    }
-
-    public boolean ping() {
-
-        try {
-            documentService.ping();
-        } catch (WebServiceException e) {
-            return false;
-        }
-
-        return true;
-    }
+    boolean ping();
 }

--- a/src/main/java/no/fint/p360/data/p360/P360FileService.java
+++ b/src/main/java/no/fint/p360/data/p360/P360FileService.java
@@ -1,75 +1,9 @@
 package no.fint.p360.data.p360;
 
-import lombok.extern.slf4j.Slf4j;
-import no.fint.arkiv.p360.file.*;
-import no.fint.p360.AdapterProps;
-import no.fint.p360.data.exception.FileNotFound;
-import no.fint.p360.data.utilities.P360Utils;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
+import no.fint.arkiv.p360.file.FileResult;
 
-import javax.annotation.PostConstruct;
-import javax.xml.namespace.QName;
-import javax.xml.ws.WebServiceException;
-import java.net.MalformedURLException;
-import java.net.URL;
+public interface P360FileService {
+    FileResult getFileByRecNo(String recNo);
 
-@Slf4j
-@Service
-public class P360FileService extends P360AbstractService {
-
-
-    private static final QName SERVICE_NAME = new QName("http://software-innovation.com/SI.Data", "FileService");
-
-    private IFileService fileServicePort;
-    private ObjectFactory objectFactory;
-
-    @Autowired
-    private AdapterProps props;
-
-    @Value("${fint.p360.wsdl-location:./src/main/resources/wsdl}/FileService.wsdl")
-    private String wsdlLocation;
-
-    public P360FileService() {
-        super("http://software-innovation.com/SI.Data", "FileService");
-    }
-
-    @PostConstruct
-    private void init() throws MalformedURLException {
-        URL wsdlLocationUrl = P360Utils.getURL(wsdlLocation);
-        log.info("WSDL location: {}", wsdlLocationUrl);
-        fileServicePort = new FileService(wsdlLocationUrl, SERVICE_NAME).getBasicHttpBindingIFileService();
-        objectFactory = new ObjectFactory();
-
-    }
-
-    public FileResult getFileByRecNo(String recNo) {
-        log.info("Retrieving {} ...", recNo);
-        GetFileWithMetadataQuery getFileWithMetadataQuery = objectFactory.createGetFileWithMetadataQuery();
-        getFileWithMetadataQuery.setRecno(objectFactory.createGetFileWithMetadataQueryRecno(Integer.parseInt(recNo)));
-        getFileWithMetadataQuery.setIncludeFileData(objectFactory.createGetFileWithMetadataQueryIncludeFileData(true));
-        getFileWithMetadataQuery.setADContextUser(objectFactory.createFileParameterBaseADContextUser(props.getP360User()));
-        GetFileWithMetadataResult fileWithMetadata = fileServicePort.getFileWithMetadata((getFileWithMetadataQuery));
-
-        if (fileWithMetadata.isSuccessful()) {
-            log.info("Retrieving {} successfully", recNo);
-            return fileWithMetadata.getFile().getValue();
-        }
-
-        log.info("Retrieving {} failed: {}", recNo, fileWithMetadata.getErrorDetails().getValue());
-        throw new FileNotFound(fileWithMetadata.getErrorMessage().getValue());
-    }
-
-
-    public boolean ping() {
-
-        try {
-            fileServicePort.ping();
-        } catch (WebServiceException e) {
-            return false;
-        }
-
-        return true;
-    }
+    boolean ping();
 }

--- a/src/main/java/no/fint/p360/data/p360/P360SupportService.java
+++ b/src/main/java/no/fint/p360/data/p360/P360SupportService.java
@@ -1,77 +1,17 @@
 package no.fint.p360.data.p360;
 
-import lombok.extern.slf4j.Slf4j;
-import no.fint.arkiv.p360.support.*;
+import no.fint.arkiv.p360.support.CodeTableRowResult;
+import no.fint.arkiv.p360.support.GetCodeTableRowsResult;
 import no.fint.p360.data.exception.CodeTableNotFound;
-import no.fint.p360.data.utilities.FintUtils;
-import no.fint.p360.data.utilities.P360Utils;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
 
-import javax.annotation.PostConstruct;
-import javax.xml.namespace.QName;
-import javax.xml.ws.WebServiceException;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.List;
 import java.util.stream.Stream;
 
-@Slf4j
-@Service
-public class P360SupportService extends P360AbstractService {
+public interface P360SupportService {
+    GetCodeTableRowsResult getCodeTable(String table) throws CodeTableNotFound;
 
-    private static final QName SERVICE_NAME = new QName("http://software-innovation.com/SI.Data", "SupportService");
+    Stream<CodeTableRowResult> getCodeTableRowResultStream(String table);
 
-    private ISupportService supportService;
-    private ObjectFactory objectFactory;
+    boolean ping();
 
-    @Value("${fint.p360.wsdl-location:./src/main/resources/wsdl}/SupportService.wsdl")
-    private String wsdlLocation;
-
-    public P360SupportService() {
-        super("http://software-innovation.com/SI.Data", "SupportService");
-    }
-
-    @PostConstruct
-    private void init() throws MalformedURLException {
-        URL wsdlLocationUrl = P360Utils.getURL(wsdlLocation);
-        log.info("WSDL location: {}", wsdlLocationUrl);
-        supportService = new SupportService(wsdlLocationUrl, SERVICE_NAME).getBasicHttpBindingISupportService();
-        super.setup(supportService, "SupportService");
-        objectFactory = new ObjectFactory();
-    }
-
-    public GetCodeTableRowsResult getCodeTable(String table) throws CodeTableNotFound {
-        GetCodeTableRowsQuery codeTableRowsQuery = objectFactory.createGetCodeTableRowsQuery();
-        codeTableRowsQuery.setCodeTableName(objectFactory.createGetCodeTableRowsQueryCodeTableName(table));
-        GetCodeTableRowsResult codeTableRows = supportService.getCodeTableRows(codeTableRowsQuery);
-        if (codeTableRows.isSuccessful()) {
-            return codeTableRows;
-        }
-
-        throw new CodeTableNotFound(String.format("Could not find %s", table));
-    }
-
-    public Stream<CodeTableRowResult> getCodeTableRowResultStream(String table) {
-        GetCodeTableRowsResult codeTable = getCodeTable(table);
-        return FintUtils.optionalValue(codeTable.getCodeTableRows())
-                .map(ArrayOfCodeTableRowResult::getCodeTableRowResult)
-                .map(List::stream)
-                .orElseThrow(() -> new CodeTableNotFound(table));
-    }
-
-    public boolean ping() {
-
-        try {
-            supportService.ping();
-        } catch (WebServiceException e) {
-            return false;
-        }
-
-        return true;
-    }
-
-    public String getSIFVersion() {
-        return supportService.getSIFVersion();
-    }
+    String getSIFVersion();
 }

--- a/src/main/java/no/fint/p360/data/p360/rpc/P360AbstractRPCService.java
+++ b/src/main/java/no/fint/p360/data/p360/rpc/P360AbstractRPCService.java
@@ -1,0 +1,56 @@
+package no.fint.p360.data.p360.rpc;
+
+import lombok.extern.slf4j.Slf4j;
+import no.fint.p360.AdapterProps;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import javax.annotation.PostConstruct;
+
+@Slf4j
+public abstract class P360AbstractRPCService {
+
+    private RestTemplate p360Client;
+
+    @Autowired
+    private RestTemplateBuilder restTemplateBuilder;
+
+    @Autowired
+    private AdapterProps adapterProps;
+
+    @PostConstruct
+    protected void init() {
+        p360Client = restTemplateBuilder
+                .rootUri(adapterProps.getEndpointBaseUrl())
+                .build();
+        log.trace("Init.");
+    }
+
+    protected <T> T call(String uri, Object args, Class<T> responseType) {
+        log.trace("POST {} {}", uri, args);
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.AUTHORIZATION, "authkey " + adapterProps.getP360Password());
+        headers.set("clientid", adapterProps.getP360User());
+        final ResponseEntity<T> entity = p360Client.exchange(uri, HttpMethod.POST, new HttpEntity<>(args, headers), responseType);
+        log.trace("POST response {} {} {}", uri, entity.getStatusCode(), entity.getHeaders());
+        return entity.getBody();
+    }
+
+    /*
+    public boolean getHealth(String url) {
+        return p360Client.post().uri(url + "?authkey={p360AuthKey}", p360AuthKey)
+                .retrieve()
+                .toBodilessEntity()
+                .blockOptional()
+                .orElseGet(() -> ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build())
+                .getStatusCode().is2xxSuccessful();
+    }
+
+     */
+}

--- a/src/main/java/no/fint/p360/data/p360/rpc/P360AbstractRPCService.java
+++ b/src/main/java/no/fint/p360/data/p360/rpc/P360AbstractRPCService.java
@@ -1,14 +1,19 @@
 package no.fint.p360.data.p360.rpc;
 
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import no.fint.p360.AdapterProps;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.web.HttpMessageConverters;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
 
 import javax.annotation.PostConstruct;
@@ -24,10 +29,23 @@ public abstract class P360AbstractRPCService {
     @Autowired
     private AdapterProps adapterProps;
 
+    private ObjectMapper objectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES);
+        return objectMapper;
+    }
+
+    private HttpMessageConverter httpMessageConverter() {
+        MappingJackson2HttpMessageConverter messageConverter = new MappingJackson2HttpMessageConverter();
+        messageConverter.setObjectMapper(objectMapper());
+        return messageConverter;
+    }
+
     @PostConstruct
     protected void init() {
         p360Client = restTemplateBuilder
                 .rootUri(adapterProps.getEndpointBaseUrl())
+                .messageConverters(httpMessageConverter())
                 .build();
         log.trace("Init.");
     }

--- a/src/main/java/no/fint/p360/data/p360/rpc/P360AccessGroupServiceRPC.java
+++ b/src/main/java/no/fint/p360/data/p360/rpc/P360AccessGroupServiceRPC.java
@@ -1,0 +1,23 @@
+package no.fint.p360.data.p360.rpc;
+
+import lombok.extern.slf4j.Slf4j;
+import no.fint.arkiv.p360.accessgroup.GetAccessGroupsQuery;
+import no.fint.arkiv.p360.accessgroup.GetAccessGroupsResult;
+import no.fint.p360.data.p360.P360AccessGroupService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@ConditionalOnProperty(name = "fint.p360.api", havingValue = "RPC")
+public class P360AccessGroupServiceRPC extends P360AbstractRPCService implements P360AccessGroupService {
+    @Override
+    public GetAccessGroupsResult getAccessGroups(GetAccessGroupsQuery parameter) {
+        return null;
+    }
+
+    @Override
+    public boolean ping() {
+        return false;
+    }
+}

--- a/src/main/java/no/fint/p360/data/p360/rpc/P360CaseServiceRPC.java
+++ b/src/main/java/no/fint/p360/data/p360/rpc/P360CaseServiceRPC.java
@@ -1,0 +1,49 @@
+package no.fint.p360.data.p360.rpc;
+
+import lombok.extern.slf4j.Slf4j;
+import no.fint.arkiv.p360.caze.CaseResult;
+import no.fint.arkiv.p360.caze.CreateCaseParameter;
+import no.fint.p360.data.exception.CreateCaseException;
+import no.fint.p360.data.exception.GetTilskuddFartoyException;
+import no.fint.p360.data.exception.GetTilskuddFartoyNotFoundException;
+import no.fint.p360.data.p360.P360CaseService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+@ConditionalOnProperty(name = "fint.p360.api", havingValue = "RPC")
+public class P360CaseServiceRPC extends P360AbstractRPCService implements P360CaseService {
+    @Override
+    public boolean ping() {
+        return false;
+    }
+
+    @Override
+    public String createCase(CreateCaseParameter createCaseParameter) throws CreateCaseException {
+        return null;
+    }
+
+    @Override
+    public CaseResult getSakByCaseNumber(String caseNumber) throws GetTilskuddFartoyNotFoundException, GetTilskuddFartoyException {
+        return null;
+    }
+
+    @Override
+    public CaseResult getSakBySystemId(String systemId) throws GetTilskuddFartoyNotFoundException, GetTilskuddFartoyException {
+        return null;
+    }
+
+    @Override
+    public CaseResult getSakByExternalId(String externalId) throws GetTilskuddFartoyNotFoundException, GetTilskuddFartoyException {
+        return null;
+    }
+
+    @Override
+    public List<CaseResult> getGetCasesQueryByTitle(Map<String, String> params) throws GetTilskuddFartoyException {
+        return null;
+    }
+}

--- a/src/main/java/no/fint/p360/data/p360/rpc/P360ContactServiceRPC.java
+++ b/src/main/java/no/fint/p360/data/p360/rpc/P360ContactServiceRPC.java
@@ -1,0 +1,74 @@
+package no.fint.p360.data.p360.rpc;
+
+import lombok.extern.slf4j.Slf4j;
+import no.fint.arkiv.p360.contact.*;
+import no.fint.p360.data.exception.CreateContactException;
+import no.fint.p360.data.exception.CreateEnterpriseException;
+import no.fint.p360.data.exception.EnterpriseNotFound;
+import no.fint.p360.data.exception.PrivatePersonNotFound;
+import no.fint.p360.data.p360.P360ContactService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+@Slf4j
+@Service
+@ConditionalOnProperty(name = "fint.p360.api", havingValue = "RPC")
+public class P360ContactServiceRPC extends P360AbstractRPCService implements P360ContactService {
+    @Override
+    public PrivatePersonResult getPrivatePersonByRecno(int recNo) {
+        return null;
+    }
+
+    @Override
+    public PrivatePersonResult getPrivatePersonByPersonalIdNumber(String personalIdNumber) throws PrivatePersonNotFound {
+        return null;
+    }
+
+    @Override
+    public ContactPersonResult getContactPersonByRecno(int recNo) {
+        return null;
+    }
+
+    @Override
+    public EnterpriseResult getEnterpriseByRecno(int recNo) {
+        return null;
+    }
+
+    @Override
+    public EnterpriseResult getEnterpriseByEnterpriseNumber(String enterpriseNumber) throws EnterpriseNotFound {
+        return null;
+    }
+
+    @Override
+    public boolean ping() {
+        return false;
+    }
+
+    @Override
+    public Stream<EnterpriseResult> searchEnterprise(Map<String, String> queryParams) {
+        return null;
+    }
+
+    @Override
+    public Stream<PrivatePersonResult> searchPrivatePerson(Map<String, String> queryParams) {
+        return null;
+    }
+
+    @Override
+    public Stream<ContactPersonResult> searchContactPerson(Map<String, String> queryParams) {
+        return null;
+    }
+
+    @Override
+    public Integer createPrivatePerson(SynchronizePrivatePersonParameter privatePerson) throws CreateContactException {
+        return null;
+    }
+
+    @Override
+    public Integer createEnterprise(SynchronizeEnterpriseParameter enterprise) throws CreateEnterpriseException {
+        return null;
+    }
+}

--- a/src/main/java/no/fint/p360/data/p360/rpc/P360DocumentServiceRPC.java
+++ b/src/main/java/no/fint/p360/data/p360/rpc/P360DocumentServiceRPC.java
@@ -1,0 +1,30 @@
+package no.fint.p360.data.p360.rpc;
+
+import lombok.extern.slf4j.Slf4j;
+import no.fint.arkiv.p360.document.CreateDocumentParameter;
+import no.fint.arkiv.p360.document.DocumentResult;
+import no.fint.p360.data.exception.CreateDocumentException;
+import no.fint.p360.data.exception.GetDocumentException;
+import no.fint.p360.data.p360.P360DocumentService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@ConditionalOnProperty(name = "fint.p360.api", havingValue = "RPC")
+public class P360DocumentServiceRPC extends P360AbstractRPCService implements P360DocumentService {
+    @Override
+    public void createDocument(CreateDocumentParameter createDocumentParameter) throws CreateDocumentException {
+
+    }
+
+    @Override
+    public DocumentResult getDocumentBySystemId(String systemId) throws GetDocumentException {
+        return null;
+    }
+
+    @Override
+    public boolean ping() {
+        return false;
+    }
+}

--- a/src/main/java/no/fint/p360/data/p360/rpc/P360FileServiceRPC.java
+++ b/src/main/java/no/fint/p360/data/p360/rpc/P360FileServiceRPC.java
@@ -1,0 +1,22 @@
+package no.fint.p360.data.p360.rpc;
+
+import lombok.extern.slf4j.Slf4j;
+import no.fint.arkiv.p360.file.FileResult;
+import no.fint.p360.data.p360.P360FileService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@ConditionalOnProperty(name = "fint.p360.api", havingValue = "RPC")
+public class P360FileServiceRPC extends P360AbstractRPCService implements P360FileService {
+    @Override
+    public FileResult getFileByRecNo(String recNo) {
+        return null;
+    }
+
+    @Override
+    public boolean ping() {
+        return false;
+    }
+}

--- a/src/main/java/no/fint/p360/data/p360/rpc/P360SupportServiceRPC.java
+++ b/src/main/java/no/fint/p360/data/p360/rpc/P360SupportServiceRPC.java
@@ -1,0 +1,38 @@
+package no.fint.p360.data.p360.rpc;
+
+import lombok.extern.slf4j.Slf4j;
+import no.fint.arkiv.p360.support.CodeTableRowResult;
+import no.fint.arkiv.p360.support.GetCodeTableRowsResult;
+import no.fint.p360.data.exception.CodeTableNotFound;
+import no.fint.p360.data.p360.P360SupportService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+@Slf4j
+@Service
+@ConditionalOnProperty(name = "fint.p360.api", havingValue = "RPC")
+public class P360SupportServiceRPC extends P360AbstractRPCService implements P360SupportService {
+    @Override
+    public GetCodeTableRowsResult getCodeTable(String table) throws CodeTableNotFound {
+        return null;
+    }
+
+    @Override
+    public Stream<CodeTableRowResult> getCodeTableRowResultStream(String table) {
+        return Stream.empty();
+    }
+
+    @Override
+    public boolean ping() {
+        final Map result = call("/SupportService/Ping", "", Map.class);
+        return result != null;
+    }
+
+    @Override
+    public String getSIFVersion() {
+        return call("/SupportService/GetSIFVersion", "", String.class);
+    }
+}

--- a/src/main/java/no/fint/p360/data/p360/soap/P360AbstractSOAPService.java
+++ b/src/main/java/no/fint/p360/data/p360/soap/P360AbstractSOAPService.java
@@ -1,4 +1,4 @@
-package no.fint.p360.data.p360;
+package no.fint.p360.data.p360.soap;
 
 import no.fint.p360.data.utilities.RequestUtilities;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -6,14 +6,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import javax.xml.namespace.QName;
 import javax.xml.ws.BindingProvider;
 
-public abstract class P360AbstractService {
+public abstract class P360AbstractSOAPService {
 
     @Autowired
     protected RequestUtilities requestUtilities;
 
     final QName serviceName;
 
-    public P360AbstractService(String namespaceURI, String localPart) {
+    public P360AbstractSOAPService(String namespaceURI, String localPart) {
         serviceName = new QName(namespaceURI, localPart);
     }
 

--- a/src/main/java/no/fint/p360/data/p360/soap/P360AccessGroupServiceSOAP.java
+++ b/src/main/java/no/fint/p360/data/p360/soap/P360AccessGroupServiceSOAP.java
@@ -1,0 +1,56 @@
+package no.fint.p360.data.p360.soap;
+
+import lombok.extern.slf4j.Slf4j;
+import no.fint.arkiv.p360.accessgroup.*;
+import no.fint.p360.data.p360.P360AccessGroupService;
+import no.fint.p360.data.utilities.P360Utils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
+import javax.xml.namespace.QName;
+import javax.xml.ws.WebServiceException;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+@Slf4j
+@Service
+public class P360AccessGroupServiceSOAP extends P360AbstractSOAPService implements P360AccessGroupService {
+
+    private static final QName SERVICE_NAME = new QName("http://software-innovation.com/SI.Data", "AccessGroupService");
+
+    private IAccessGroupService accessGroupService;
+    private ObjectFactory objectFactory;
+
+    @Value("${fint.p360.wsdl-location:./src/main/resources/wsdl}/AccessGroupService.wsdl")
+    private String wsdlLocation;
+
+    public P360AccessGroupServiceSOAP() {
+        super("http://software-innovation.com/SI.Data", "AccessGroupService");
+    }
+
+    @PostConstruct
+    private void init() throws MalformedURLException {
+        URL wsdlLocationUrl = P360Utils.getURL(wsdlLocation);
+        log.info("WSDL location: {}", wsdlLocationUrl);
+        accessGroupService = new AccessGroupService(wsdlLocationUrl, SERVICE_NAME).getBasicHttpBindingIAccessGroupService();
+        super.setup(accessGroupService, "AccessGroupService");
+        objectFactory = new ObjectFactory();
+    }
+
+    @Override public GetAccessGroupsResult getAccessGroups(GetAccessGroupsQuery parameter) {
+        return accessGroupService.getAccessGroups(parameter);
+    }
+
+    @Override public boolean ping() {
+
+        try {
+            accessGroupService.ping();
+        } catch (WebServiceException e) {
+            return false;
+        }
+
+        return true;
+    }
+
+}

--- a/src/main/java/no/fint/p360/data/p360/soap/P360AccessGroupServiceSOAP.java
+++ b/src/main/java/no/fint/p360/data/p360/soap/P360AccessGroupServiceSOAP.java
@@ -5,6 +5,7 @@ import no.fint.arkiv.p360.accessgroup.*;
 import no.fint.p360.data.p360.P360AccessGroupService;
 import no.fint.p360.data.utilities.P360Utils;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.PostConstruct;
@@ -15,6 +16,7 @@ import java.net.URL;
 
 @Slf4j
 @Service
+@ConditionalOnProperty(name = "fint.p360.api", havingValue = "SOAP")
 public class P360AccessGroupServiceSOAP extends P360AbstractSOAPService implements P360AccessGroupService {
 
     private static final QName SERVICE_NAME = new QName("http://software-innovation.com/SI.Data", "AccessGroupService");

--- a/src/main/java/no/fint/p360/data/p360/soap/P360CaseServiceSOAP.java
+++ b/src/main/java/no/fint/p360/data/p360/soap/P360CaseServiceSOAP.java
@@ -1,0 +1,124 @@
+package no.fint.p360.data.p360.soap;
+
+import lombok.extern.slf4j.Slf4j;
+import no.fint.arkiv.p360.caze.*;
+import no.fint.p360.data.exception.CreateCaseException;
+import no.fint.p360.data.exception.GetTilskuddFartoyException;
+import no.fint.p360.data.exception.GetTilskuddFartoyNotFoundException;
+import no.fint.p360.data.p360.P360CaseService;
+import no.fint.p360.data.utilities.Constants;
+import no.fint.p360.data.utilities.P360Utils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
+import javax.xml.ws.WebServiceException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@Slf4j
+public class P360CaseServiceSOAP extends P360AbstractSOAPService implements P360CaseService {
+
+
+    private ICaseService caseServicePort;
+
+    private ObjectFactory objectFactory;
+
+    @Value("${fint.p360.wsdl-location:./src/main/resources/wsdl}/CaseService.wsdl")
+    private String wsdlLocation;
+
+    public P360CaseServiceSOAP() {
+        super("http://software-innovation.com/SI.Data", "CaseService");
+    }
+
+    @PostConstruct
+    public void init() throws MalformedURLException {
+        URL wsdlLocationUrl = P360Utils.getURL(wsdlLocation);
+        log.info("WSDL location: {}", wsdlLocationUrl);
+        caseServicePort = new CaseService(wsdlLocationUrl, serviceName).getBasicHttpBindingICaseService();
+        super.setup(caseServicePort, "CaseService");
+
+        objectFactory = new ObjectFactory();
+    }
+
+    @Override public boolean ping() {
+        try {
+            caseServicePort.ping();
+        } catch (WebServiceException e) {
+            return false;
+        }
+
+        return true;
+    }
+
+
+    @Override public String createCase(CreateCaseParameter createCaseParameter) throws CreateCaseException {
+        log.info("Create case: {}", createCaseParameter);
+        CaseOperationResult operationResult = caseServicePort.createCase(createCaseParameter);
+        log.info("Create case result: {}", operationResult);
+        if (operationResult.isSuccessful()) {
+            return operationResult.getCaseNumber().getValue();
+        } else {
+            throw new CreateCaseException(operationResult.getErrorDetails().getValue());
+        }
+    }
+
+    @Override public CaseResult getSakByCaseNumber(String caseNumber) throws GetTilskuddFartoyNotFoundException, GetTilskuddFartoyException {
+        GetCasesQuery getCasesQuery = new GetCasesQuery();
+        getCasesQuery.setCaseNumber(objectFactory.createGetCasesQueryCaseNumber(caseNumber));
+        return getCase(getCasesQuery);
+    }
+
+    @Override public CaseResult getSakBySystemId(String systemId) throws GetTilskuddFartoyNotFoundException, GetTilskuddFartoyException {
+        GetCasesQuery getCasesQuery = new GetCasesQuery();
+        getCasesQuery.setRecno(objectFactory.createGetCasesQueryRecno(Integer.valueOf(systemId)));
+        return getCase(getCasesQuery);
+    }
+
+    @Override public CaseResult getSakByExternalId(String externalId) throws GetTilskuddFartoyNotFoundException, GetTilskuddFartoyException {
+        GetCasesQuery getCasesQuery = objectFactory.createGetCasesQuery();
+        ExternalIdParameter externalIdParameter = objectFactory.createExternalIdParameter();
+        externalIdParameter.setType(objectFactory.createExternalIdParameterType(Constants.EXTERNAL_ID_TYPE));
+        externalIdParameter.setId(objectFactory.createExternalIdParameterId(externalId));
+        getCasesQuery.setExternalId(objectFactory.createGetCasesQueryExternalId(externalIdParameter));
+        return getCase(getCasesQuery);
+    }
+
+    @Override public List<CaseResult> getGetCasesQueryByTitle(Map<String, String> params) throws GetTilskuddFartoyException {
+        GetCasesQuery getCasesQuery = new GetCasesQuery();
+        getCasesQuery.setTitle(objectFactory.createGetCasesQueryTitle(String.format("%%%s%%", params.get("title"))));
+        getCasesQuery.setMaxReturnedCases(objectFactory.createGetCasesQueryMaxReturnedCases(Integer.valueOf(params.getOrDefault("maxResult", "10"))));
+        getCasesQuery.setIncludeCustomFields(Boolean.TRUE);
+        return getCases(getCasesQuery);
+    }
+
+    private List<CaseResult> getCases(GetCasesQuery casesQuery) throws GetTilskuddFartoyException {
+        GetCasesResult cases = caseServicePort.getCases(casesQuery);
+
+        if (cases.isSuccessful()) {
+            return cases.getCases().getValue().getCaseResult();
+        }
+        throw new GetTilskuddFartoyException(cases.getErrorDetails().getValue());
+    }
+
+    private CaseResult getCase(GetCasesQuery casesQuery) throws GetTilskuddFartoyNotFoundException, GetTilskuddFartoyException {
+        casesQuery.setIncludeCustomFields(Boolean.TRUE);
+        casesQuery.setIncludeCaseContacts(Boolean.TRUE);
+        log.info("Query: {}", casesQuery);
+        GetCasesResult cases = caseServicePort.getCases(casesQuery);
+        log.info("Cases: {}", cases);
+
+        if (cases.isSuccessful() && cases.getTotalPageCount().getValue() == 1) {
+            return cases.getCases().getValue().getCaseResult().get(0);
+        }
+        if (cases.getTotalPageCount().getValue() != 1) {
+            throw new GetTilskuddFartoyNotFoundException("Case could not be found");
+        }
+        throw new GetTilskuddFartoyException(cases.getErrorDetails().getValue());
+    }
+
+
+}

--- a/src/main/java/no/fint/p360/data/p360/soap/P360CaseServiceSOAP.java
+++ b/src/main/java/no/fint/p360/data/p360/soap/P360CaseServiceSOAP.java
@@ -9,6 +9,7 @@ import no.fint.p360.data.p360.P360CaseService;
 import no.fint.p360.data.utilities.Constants;
 import no.fint.p360.data.utilities.P360Utils;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.PostConstruct;
@@ -20,6 +21,7 @@ import java.util.Map;
 
 @Service
 @Slf4j
+@ConditionalOnProperty(name = "fint.p360.api", havingValue = "SOAP")
 public class P360CaseServiceSOAP extends P360AbstractSOAPService implements P360CaseService {
 
 

--- a/src/main/java/no/fint/p360/data/p360/soap/P360ContactServiceSOAP.java
+++ b/src/main/java/no/fint/p360/data/p360/soap/P360ContactServiceSOAP.java
@@ -9,6 +9,7 @@ import no.fint.p360.data.exception.PrivatePersonNotFound;
 import no.fint.p360.data.p360.P360ContactService;
 import no.fint.p360.data.utilities.P360Utils;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.PostConstruct;
@@ -21,6 +22,7 @@ import java.util.stream.Stream;
 
 @Slf4j
 @Service
+@ConditionalOnProperty(name = "fint.p360.api", havingValue = "SOAP")
 public class P360ContactServiceSOAP extends P360AbstractSOAPService implements P360ContactService {
 
     private static final QName SERVICE_NAME = new QName("http://software-innovation.com/SI.Data", "ContactService");

--- a/src/main/java/no/fint/p360/data/p360/soap/P360ContactServiceSOAP.java
+++ b/src/main/java/no/fint/p360/data/p360/soap/P360ContactServiceSOAP.java
@@ -1,0 +1,223 @@
+package no.fint.p360.data.p360.soap;
+
+import lombok.extern.slf4j.Slf4j;
+import no.fint.arkiv.p360.contact.*;
+import no.fint.p360.data.exception.CreateContactException;
+import no.fint.p360.data.exception.CreateEnterpriseException;
+import no.fint.p360.data.exception.EnterpriseNotFound;
+import no.fint.p360.data.exception.PrivatePersonNotFound;
+import no.fint.p360.data.p360.P360ContactService;
+import no.fint.p360.data.utilities.P360Utils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
+import javax.xml.namespace.QName;
+import javax.xml.ws.WebServiceException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Map;
+import java.util.stream.Stream;
+
+@Slf4j
+@Service
+public class P360ContactServiceSOAP extends P360AbstractSOAPService implements P360ContactService {
+
+    private static final QName SERVICE_NAME = new QName("http://software-innovation.com/SI.Data", "ContactService");
+
+    private IContactService contactService;
+    private ObjectFactory objectFactory;
+
+    @Value("${fint.p360.wsdl-location:./src/main/resources/wsdl}/ContactService.wsdl")
+    private String wsdlLocation;
+
+    public P360ContactServiceSOAP() {
+        super("http://software-innovation.com/SI.Data", "ContactService");
+    }
+
+    @PostConstruct
+    private void init() throws MalformedURLException {
+        URL wsdlLocationUrl = P360Utils.getURL(wsdlLocation);
+        log.info("WSDL location: {}", wsdlLocationUrl);
+        contactService = new ContactService(wsdlLocationUrl, SERVICE_NAME).getBasicHttpBindingIContactService();
+        super.setup(contactService, "ContactService");
+
+        objectFactory = new ObjectFactory();
+    }
+
+    @Override public PrivatePersonResult getPrivatePersonByRecno(int recNo) {
+        GetPrivatePersonsParameter getPrivatePersonsParameter = new GetPrivatePersonsParameter();
+        getPrivatePersonsParameter.setIncludeCustomFields(Boolean.TRUE);
+        getPrivatePersonsParameter.setRecno(objectFactory.createGetPrivatePersonsParameterRecno(recNo));
+        GetPrivatePersonsResult privatePersons = contactService.getPrivatePersons(getPrivatePersonsParameter);
+
+        log.info("PrivatePersonsResult: {}", privatePersons);
+
+        if (privatePersons.isSuccessful() && privatePersons.getTotalPageCount().getValue() == 1) {
+            return privatePersons.getPrivatePersons().getValue().getPrivatePersonResult().get(0);
+        }
+        return null;
+    }
+
+    @Override public PrivatePersonResult getPrivatePersonByPersonalIdNumber(String personalIdNumber) throws PrivatePersonNotFound {
+        GetPrivatePersonsParameter getPrivatePersonsParameter = objectFactory.createGetPrivatePersonsParameter();
+        getPrivatePersonsParameter.setIncludeCustomFields(Boolean.TRUE);
+
+        getPrivatePersonsParameter.setPersonalIdNumber(
+                objectFactory.createGetPrivatePersonsParameterPersonalIdNumber(personalIdNumber));
+
+        GetPrivatePersonsResult privatePersons = contactService.getPrivatePersons(getPrivatePersonsParameter);
+
+        log.info("PrivatePersonsResult: {}", privatePersons);
+
+        if (privatePersons.isSuccessful() && privatePersons.getTotalPageCount().getValue() == 1) {
+            return privatePersons.getPrivatePersons().getValue().getPrivatePersonResult().get(0);
+        }
+
+        throw new PrivatePersonNotFound(privatePersons.getErrorMessage().getValue());
+    }
+
+    @Override public ContactPersonResult getContactPersonByRecno(int recNo) {
+
+        GetContactPersonsParameter getContactPersonsParameter = new GetContactPersonsParameter();
+        getContactPersonsParameter.setIncludeCustomFields(Boolean.TRUE);
+        getContactPersonsParameter.setRecno(objectFactory.createGetContactPersonsParameterRecno(recNo));
+        GetContactPersonsResult contactPersons = contactService.getContactPersons(getContactPersonsParameter);
+
+        log.info("ContactPersonsResult: {}", contactPersons);
+
+        if (contactPersons.isSuccessful() && contactPersons.getTotalPageCount().getValue() == 1) {
+            return contactPersons.getContactPersons().getValue().getContactPersonResult().get(0);
+        }
+        return null;
+    }
+
+    @Override public EnterpriseResult getEnterpriseByRecno(int recNo) {
+
+        GetEnterprisesParameter getEnterpriseParameter = new GetEnterprisesParameter();
+        getEnterpriseParameter.setIncludeCustomFields(Boolean.TRUE);
+        getEnterpriseParameter.setRecno(objectFactory.createGetEnterprisesParameterRecno(recNo));
+        GetEnterprisesResult enterprises = contactService.getEnterprises(getEnterpriseParameter);
+
+        log.info("EnterpriseResult: {}", enterprises);
+
+        if (enterprises.isSuccessful() && enterprises.getTotalPageCount().getValue() == 1) {
+            return enterprises.getEnterprises().getValue().getEnterpriseResult().get(0);
+        }
+
+        return null;
+    }
+
+    @Override public EnterpriseResult getEnterpriseByEnterpriseNumber(String enterpriseNumber) throws EnterpriseNotFound {
+        GetEnterprisesParameter getEnterprisesParameter = objectFactory.createGetEnterprisesParameter();
+        getEnterprisesParameter.setIncludeCustomFields(Boolean.TRUE);
+        getEnterprisesParameter.setEnterpriseNumber(objectFactory.createGetEnterprisesParameterEnterpriseNumber(enterpriseNumber));
+
+        GetEnterprisesResult enterprises = contactService.getEnterprises(getEnterprisesParameter);
+
+        log.info("EnterpriseResult: {}", enterprises);
+
+        if (enterprises.isSuccessful() && enterprises.getTotalPageCount().getValue() == 1) {
+            return enterprises.getEnterprises().getValue().getEnterpriseResult().get(0);
+        }
+
+        throw new EnterpriseNotFound(enterprises.getErrorMessage().getValue());
+    }
+
+    @Override public boolean ping() {
+
+        try {
+            contactService.ping();
+        } catch (WebServiceException e) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override public Stream<EnterpriseResult> searchEnterprise(Map<String, String> queryParams) {
+        GetEnterprisesParameter getEnterprisesParameter = objectFactory.createGetEnterprisesParameter();
+        if (queryParams.containsKey("navn")) {
+            getEnterprisesParameter.setName(objectFactory.createGetEnterprisesParameterName(queryParams.get("navn")));
+        }
+        if (queryParams.containsKey("organisasjonsnummer")) {
+            getEnterprisesParameter.setEnterpriseNumber(objectFactory.createGetEnterprisesParameterEnterpriseNumber(queryParams.get("organisasjonsnummer")));
+        }
+        if (queryParams.containsKey("maxResults")) {
+            getEnterprisesParameter.setMaxRows(objectFactory.createGetEnterprisesParameterMaxRows(Integer.valueOf(queryParams.get("maxResults"))));
+        }
+
+        log.info("GetEnterprises query: {}", getEnterprisesParameter);
+        GetEnterprisesResult result = contactService.getEnterprises(getEnterprisesParameter);
+        log.info("GetEnterprises result: {}", result);
+
+        if (!result.isSuccessful()) {
+            return Stream.empty();
+        }
+
+        return result.getEnterprises().getValue().getEnterpriseResult().stream();
+    }
+
+    @Override public Stream<PrivatePersonResult> searchPrivatePerson(Map<String, String> queryParams) {
+        GetPrivatePersonsParameter getPrivatePersonsParameter = objectFactory.createGetPrivatePersonsParameter();
+        if (queryParams.containsKey("navn")) {
+            getPrivatePersonsParameter.setName(objectFactory.createGetPrivatePersonsParameterName(queryParams.get("navn")));
+        }
+        if (queryParams.containsKey("maxResults")) {
+            getPrivatePersonsParameter.setMaxRows(objectFactory.createGetPrivatePersonsParameterMaxRows(Integer.valueOf(queryParams.get("maxResults"))));
+        }
+
+        log.info("GetPrivatePersons query: {}", getPrivatePersonsParameter);
+        GetPrivatePersonsResult result = contactService.getPrivatePersons(getPrivatePersonsParameter);
+        log.info("GetPrivatePersons: {}", result);
+
+        if (!result.isSuccessful()) {
+            return Stream.empty();
+        }
+
+        return result.getPrivatePersons().getValue().getPrivatePersonResult().stream();
+    }
+
+    @Override public Stream<ContactPersonResult> searchContactPerson(Map<String, String> queryParams) {
+        GetContactPersonsParameter getContactPersonsParameter = objectFactory.createGetContactPersonsParameter();
+
+        if (queryParams.containsKey("navn")) {
+            getContactPersonsParameter.setName(objectFactory.createGetPrivatePersonsParameterName(queryParams.get("navn")));
+        }
+        if (queryParams.containsKey("maxResults")) {
+            getContactPersonsParameter.setMaxRows(objectFactory.createGetPrivatePersonsParameterMaxRows(Integer.valueOf(queryParams.get("maxResults"))));
+        }
+
+        log.info("GetContactPersons query: {}", getContactPersonsParameter);
+        GetContactPersonsResult result = contactService.getContactPersons(getContactPersonsParameter);
+        log.info("GetContactPersons result: {}", result);
+
+        if (!result.isSuccessful()) {
+            return Stream.empty();
+        }
+
+        return result.getContactPersons().getValue().getContactPersonResult().stream();
+    }
+
+    @Override public Integer createPrivatePerson(SynchronizePrivatePersonParameter privatePerson) throws CreateContactException {
+        log.info("Create Private Person: {}", privatePerson);
+        SynchronizePrivatePersonResult privatePersonResult = contactService.synchronizePrivatePerson(privatePerson);
+        log.info("Private Person Result: {}", privatePersonResult);
+        if (privatePersonResult.isSuccessful()) {
+            return privatePersonResult.getRecno();
+        }
+        throw new CreateContactException(privatePersonResult.getErrorMessage().getValue());
+    }
+
+    @Override public Integer createEnterprise(SynchronizeEnterpriseParameter enterprise) throws CreateEnterpriseException {
+        log.info("Create Enterprise: {}", enterprise);
+        SynchronizeEnterpriseResult result = contactService.synchronizeEnterprise(enterprise);
+        log.info("Enterprise Result: {}", result);
+        if (result.isSuccessful()) {
+            return result.getRecno();
+        }
+        throw new CreateEnterpriseException(result.getErrorMessage().getValue());
+    }
+
+}
+

--- a/src/main/java/no/fint/p360/data/p360/soap/P360DocumentServiceSOAP.java
+++ b/src/main/java/no/fint/p360/data/p360/soap/P360DocumentServiceSOAP.java
@@ -1,0 +1,81 @@
+package no.fint.p360.data.p360.soap;
+
+import lombok.extern.slf4j.Slf4j;
+import no.fint.arkiv.p360.document.*;
+import no.fint.p360.data.exception.CreateDocumentException;
+import no.fint.p360.data.exception.GetDocumentException;
+import no.fint.p360.data.p360.P360DocumentService;
+import no.fint.p360.data.utilities.P360Utils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
+import javax.xml.ws.WebServiceException;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+@Service
+@Slf4j
+public class P360DocumentServiceSOAP extends P360AbstractSOAPService implements P360DocumentService {
+
+    private IDocumentService documentService;
+    private ObjectFactory objectFactory;
+
+    @Value("${fint.p360.wsdl-location:./src/main/resources/wsdl}/DocumentService.wsdl")
+    private String wsdlLocation;
+
+    public P360DocumentServiceSOAP() {
+        super("http://software-innovation.com/SI.Data", "DocumentService");
+    }
+
+    @PostConstruct
+    private void init() throws MalformedURLException {
+        URL wsdlLocationUrl = P360Utils.getURL(wsdlLocation);
+        log.info("WSDL location: {}", wsdlLocationUrl);
+        documentService = new DocumentService(wsdlLocationUrl, serviceName).getBasicHttpBindingIDocumentService();
+        super.setup(documentService, "DocumentService");
+
+        objectFactory = new ObjectFactory();
+    }
+
+    @Override public void createDocument(CreateDocumentParameter createDocumentParameter) throws CreateDocumentException {
+        log.info("Create Document: {}", createDocumentParameter);
+        DocumentOperationResult documentOperationResult = documentService.createDocument(createDocumentParameter);
+        log.info("Create Document Result: {}", documentOperationResult);
+        if (documentOperationResult.isSuccessful()) {
+            log.info("Documents successfully created");
+            return;
+        }
+        throw new CreateDocumentException(documentOperationResult.getErrorMessage().getValue());
+    }
+
+    @Override public DocumentResult getDocumentBySystemId(String systemId) throws GetDocumentException {
+        GetDocumentsQuery documentsQuery = new GetDocumentsQuery();
+        documentsQuery.setRecno(objectFactory.createGetDocumentsQueryRecno(Integer.valueOf(systemId)));
+        documentsQuery.setIncludeRemarks(Boolean.TRUE);
+        documentsQuery.setIncludeCustomFields(Boolean.TRUE);
+
+        GetDocumentsResult documentsResult = documentService.getDocuments(documentsQuery);
+
+        log.info("DocumentsResult: {}", documentsResult);
+
+        if (documentsResult.isSuccessful() && documentsResult.getTotalPageCount().getValue() == 1) {
+            return documentsResult.getDocuments().getValue().getDocumentResult().get(0);
+        }
+        if (documentsResult.getTotalPageCount().getValue() != 1) {
+            throw new GetDocumentException("Document could not be found");
+        }
+        throw new GetDocumentException(documentsResult.getErrorDetails().getValue());
+    }
+
+    @Override public boolean ping() {
+
+        try {
+            documentService.ping();
+        } catch (WebServiceException e) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/no/fint/p360/data/p360/soap/P360DocumentServiceSOAP.java
+++ b/src/main/java/no/fint/p360/data/p360/soap/P360DocumentServiceSOAP.java
@@ -7,6 +7,7 @@ import no.fint.p360.data.exception.GetDocumentException;
 import no.fint.p360.data.p360.P360DocumentService;
 import no.fint.p360.data.utilities.P360Utils;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.PostConstruct;
@@ -16,6 +17,7 @@ import java.net.URL;
 
 @Service
 @Slf4j
+@ConditionalOnProperty(name = "fint.p360.api", havingValue = "SOAP")
 public class P360DocumentServiceSOAP extends P360AbstractSOAPService implements P360DocumentService {
 
     private IDocumentService documentService;

--- a/src/main/java/no/fint/p360/data/p360/soap/P360FileServiceSOAP.java
+++ b/src/main/java/no/fint/p360/data/p360/soap/P360FileServiceSOAP.java
@@ -1,0 +1,76 @@
+package no.fint.p360.data.p360.soap;
+
+import lombok.extern.slf4j.Slf4j;
+import no.fint.arkiv.p360.file.*;
+import no.fint.p360.AdapterProps;
+import no.fint.p360.data.exception.FileNotFound;
+import no.fint.p360.data.p360.P360FileService;
+import no.fint.p360.data.utilities.P360Utils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
+import javax.xml.namespace.QName;
+import javax.xml.ws.WebServiceException;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+@Slf4j
+@Service
+public class P360FileServiceSOAP extends P360AbstractSOAPService implements P360FileService {
+
+
+    private static final QName SERVICE_NAME = new QName("http://software-innovation.com/SI.Data", "FileService");
+
+    private IFileService fileServicePort;
+    private ObjectFactory objectFactory;
+
+    @Autowired
+    private AdapterProps props;
+
+    @Value("${fint.p360.wsdl-location:./src/main/resources/wsdl}/FileService.wsdl")
+    private String wsdlLocation;
+
+    public P360FileServiceSOAP() {
+        super("http://software-innovation.com/SI.Data", "FileService");
+    }
+
+    @PostConstruct
+    private void init() throws MalformedURLException {
+        URL wsdlLocationUrl = P360Utils.getURL(wsdlLocation);
+        log.info("WSDL location: {}", wsdlLocationUrl);
+        fileServicePort = new FileService(wsdlLocationUrl, SERVICE_NAME).getBasicHttpBindingIFileService();
+        objectFactory = new ObjectFactory();
+
+    }
+
+    @Override public FileResult getFileByRecNo(String recNo) {
+        log.info("Retrieving {} ...", recNo);
+        GetFileWithMetadataQuery getFileWithMetadataQuery = objectFactory.createGetFileWithMetadataQuery();
+        getFileWithMetadataQuery.setRecno(objectFactory.createGetFileWithMetadataQueryRecno(Integer.parseInt(recNo)));
+        getFileWithMetadataQuery.setIncludeFileData(objectFactory.createGetFileWithMetadataQueryIncludeFileData(true));
+        getFileWithMetadataQuery.setADContextUser(objectFactory.createFileParameterBaseADContextUser(props.getP360User()));
+        GetFileWithMetadataResult fileWithMetadata = fileServicePort.getFileWithMetadata((getFileWithMetadataQuery));
+
+        if (fileWithMetadata.isSuccessful()) {
+            log.info("Retrieving {} successfully", recNo);
+            return fileWithMetadata.getFile().getValue();
+        }
+
+        log.info("Retrieving {} failed: {}", recNo, fileWithMetadata.getErrorDetails().getValue());
+        throw new FileNotFound(fileWithMetadata.getErrorMessage().getValue());
+    }
+
+
+    @Override public boolean ping() {
+
+        try {
+            fileServicePort.ping();
+        } catch (WebServiceException e) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/no/fint/p360/data/p360/soap/P360FileServiceSOAP.java
+++ b/src/main/java/no/fint/p360/data/p360/soap/P360FileServiceSOAP.java
@@ -8,6 +8,7 @@ import no.fint.p360.data.p360.P360FileService;
 import no.fint.p360.data.utilities.P360Utils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.PostConstruct;
@@ -18,6 +19,7 @@ import java.net.URL;
 
 @Slf4j
 @Service
+@ConditionalOnProperty(name = "fint.p360.api", havingValue = "SOAP")
 public class P360FileServiceSOAP extends P360AbstractSOAPService implements P360FileService {
 
 

--- a/src/main/java/no/fint/p360/data/p360/soap/P360SupportServiceSOAP.java
+++ b/src/main/java/no/fint/p360/data/p360/soap/P360SupportServiceSOAP.java
@@ -7,6 +7,7 @@ import no.fint.p360.data.p360.P360SupportService;
 import no.fint.p360.data.utilities.FintUtils;
 import no.fint.p360.data.utilities.P360Utils;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.PostConstruct;
@@ -19,6 +20,7 @@ import java.util.stream.Stream;
 
 @Slf4j
 @Service
+@ConditionalOnProperty(name = "fint.p360.api", havingValue = "SOAP")
 public class P360SupportServiceSOAP extends P360AbstractSOAPService implements P360SupportService {
 
     private static final QName SERVICE_NAME = new QName("http://software-innovation.com/SI.Data", "SupportService");

--- a/src/main/java/no/fint/p360/data/p360/soap/P360SupportServiceSOAP.java
+++ b/src/main/java/no/fint/p360/data/p360/soap/P360SupportServiceSOAP.java
@@ -1,0 +1,82 @@
+package no.fint.p360.data.p360.soap;
+
+import lombok.extern.slf4j.Slf4j;
+import no.fint.arkiv.p360.support.*;
+import no.fint.p360.data.exception.CodeTableNotFound;
+import no.fint.p360.data.p360.P360SupportService;
+import no.fint.p360.data.utilities.FintUtils;
+import no.fint.p360.data.utilities.P360Utils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
+import javax.xml.namespace.QName;
+import javax.xml.ws.WebServiceException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+import java.util.stream.Stream;
+
+@Slf4j
+@Service
+public class P360SupportServiceSOAP extends P360AbstractSOAPService implements P360SupportService {
+
+    private static final QName SERVICE_NAME = new QName("http://software-innovation.com/SI.Data", "SupportService");
+
+    private ISupportService supportService;
+    private ObjectFactory objectFactory;
+
+    @Value("${fint.p360.wsdl-location:./src/main/resources/wsdl}/SupportService.wsdl")
+    private String wsdlLocation;
+
+    public P360SupportServiceSOAP() {
+        super("http://software-innovation.com/SI.Data", "SupportService");
+    }
+
+    @PostConstruct
+    private void init() throws MalformedURLException {
+        URL wsdlLocationUrl = P360Utils.getURL(wsdlLocation);
+        log.info("WSDL location: {}", wsdlLocationUrl);
+        supportService = new SupportService(wsdlLocationUrl, SERVICE_NAME).getBasicHttpBindingISupportService();
+        super.setup(supportService, "SupportService");
+        objectFactory = new ObjectFactory();
+    }
+
+    @Override
+    public GetCodeTableRowsResult getCodeTable(String table) throws CodeTableNotFound {
+        GetCodeTableRowsQuery codeTableRowsQuery = objectFactory.createGetCodeTableRowsQuery();
+        codeTableRowsQuery.setCodeTableName(objectFactory.createGetCodeTableRowsQueryCodeTableName(table));
+        GetCodeTableRowsResult codeTableRows = supportService.getCodeTableRows(codeTableRowsQuery);
+        if (codeTableRows.isSuccessful()) {
+            return codeTableRows;
+        }
+
+        throw new CodeTableNotFound(String.format("Could not find %s", table));
+    }
+
+    @Override
+    public Stream<CodeTableRowResult> getCodeTableRowResultStream(String table) {
+        GetCodeTableRowsResult codeTable = getCodeTable(table);
+        return FintUtils.optionalValue(codeTable.getCodeTableRows())
+                .map(ArrayOfCodeTableRowResult::getCodeTableRowResult)
+                .map(List::stream)
+                .orElseThrow(() -> new CodeTableNotFound(table));
+    }
+
+    @Override
+    public boolean ping() {
+
+        try {
+            supportService.ping();
+        } catch (WebServiceException e) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public String getSIFVersion() {
+        return supportService.getSIFVersion();
+    }
+}


### PR DESCRIPTION
RPC uses same objects as SOAP, so the WSDL objects can be reused.

The P360 services can be implemented both as SOAP and RPC.